### PR TITLE
Revert "Bump custom-electron-titlebar from 4.1.3 to 4.2.8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "child_process": "^1.0.2",
-    "custom-electron-titlebar": "^4.2.8",
+    "custom-electron-titlebar": "^4.1.0",
     "electron-context-menu": "^3.6.1",
     "electron-updater": "^6.1.8"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,10 +543,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-custom-electron-titlebar@^4.2.8:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/custom-electron-titlebar/-/custom-electron-titlebar-4.2.8.tgz#8b0d024cf372b10c9758cc512ca55498b69616da"
-  integrity sha512-JEFiOKJdSZtMh90FO90FeEqCc463ZZhuh78JxILvO9Nc0H8I9MfKekgCf6jZH6xccd3/tm1OcYOoUJi3JbXR/w==
+custom-electron-titlebar@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/custom-electron-titlebar/-/custom-electron-titlebar-4.1.3.tgz#6b5d0527858bae89314f3d0b4e6a0b9be4efad81"
+  integrity sha512-9tqiRxp7KG3qgS5Qh0ejSTwzqJ/pkB8RXQrvZHmilIzaWFmvjHiaSnHgCj+1iJcnhvzACYXFiFo2fxD64kFi4A==
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"


### PR DESCRIPTION
Reverts NZero-Labs/intranet-electron#1